### PR TITLE
Translate documentation and messages to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,44 @@
 # Changelog
 
-Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
+All notable changes to this project will be documented in this file.
 
-O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/), e este projeto segue [SemVer](https://semver.org/lang/pt-BR/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [SemVer](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2025-06-05
+
+### Changed
+
+-   All documentation, comments, docblocks, and user-facing messages translated from Portuguese to English.
+-   README, CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, CHANGELOG, and all code comments are now in English.
+-   Project is now fully standardized for the international open-source community.
 
 ## [1.1.0] - 2025-06-03
 
-### Adicionado
+### Added
 
--   Arquivo CHANGELOG.md seguindo o padrão Keep a Changelog.
--   Workflow de CI com lint, análise estática e testes automatizados.
--   Ferramentas de análise estática (PHPStan), lint (PHP CS Fixer) e PSR-12.
--   Arquivos CONTRIBUTING.md e CODE_OF_CONDUCT.md para facilitar contribuições e manter boas práticas.
--   Exemplo de uso com interface fluente e tratamento de exceções no `index.php`.
--   Badge de status do CI, licença e Packagist no README.
+-   CHANGELOG.md file following the Keep a Changelog standard.
+-   CI workflow with lint, static analysis, and automated tests.
+-   Static analysis tools (PHPStan), lint (PHP CS Fixer), and PSR-12.
+-   CONTRIBUTING.md and CODE_OF_CONDUCT.md files to facilitate contributions and maintain best practices.
+-   Usage example with fluent interface and exception handling in `index.php`.
+-   CI status, license, and Packagist badges in the README.
 
-### Alterado
+### Changed
 
--   Código principal refatorado para interface fluente, validação de parâmetros e documentação aprimorada.
--   Testes automatizados expandidos para cobrir todos os fluxos, inclusive exceções e edge cases.
--   README.md atualizado com instruções de uso, contribuição, execução de testes, lint e análise estática.
--   Padronização de código para PSR-12 e boas práticas open-source.
+-   Main code refactored for fluent interface, parameter validation, and improved documentation.
+-   Automated tests expanded to cover all flows, including exceptions and edge cases.
+-   README.md updated with usage instructions, contribution, running tests, lint, and static analysis.
+-   Code standardized to PSR-12 and open-source best practices.
 
 ## [1.0.0] - 2025-06-03
 
-### Adicionado
+### Added
 
--   Primeira versão estável.
--   Geração de senhas seguras com opções de minúsculas, maiúsculas, números e caracteres especiais.
--   Interface fluente para configuração.
--   Testes automatizados cobrindo todos os cenários principais e de erro.
--   Documentação completa, exemplos de uso e instruções de contribuição.
--   CI com lint, análise estática e testes.
--   Licença GPL-3.0-or-later.
+-   First stable release.
+-   Secure password generation with options for lowercase, uppercase, numbers, and special characters.
+-   Fluent interface for configuration.
+-   Automated tests covering all main and error scenarios.
+-   Complete documentation, usage examples, and contribution instructions.
+-   CI with lint, static analysis, and tests.
+-   GPL-3.0-or-later license.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Código de Conduta
+# Code of Conduct
 
-Todos os participantes deste projeto devem aderir ao [Código de Conduta do Contributor Covenant](https://www.contributor-covenant.org/pt-br/version/2/0/code_of_conduct/).
+All participants in this project must adhere to the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
-# Como contribuir
+# Contributing
 
-Obrigado por considerar contribuir com este projeto!
+Thank you for considering contributing to this project!
 
-## Como enviar contribuições
+## How to contribute
 
-1. Faça um fork do repositório
-2. Crie uma branch para sua feature ou correção (`git checkout -b minha-feature`)
-3. Faça commit das suas alterações (`git commit -am 'Minha nova feature'`)
-4. Faça push para a branch (`git push origin minha-feature`)
-5. Abra um Pull Request
+1. Fork the repository
+2. Create a branch for your feature or fix (`git checkout -b my-feature`)
+3. Commit your changes (`git commit -am 'My new feature'`)
+4. Push to the branch (`git push origin my-feature`)
+5. Open a Pull Request
 
-## Padrões de código
+## Code standards
 
--   Siga o padrão PSR-12
--   Execute `vendor/bin/php-cs-fixer fix --dry-run --diff` antes de enviar
--   Execute `vendor/bin/phpstan analyse` para análise estática
--   Adicione testes para novas funcionalidades
+-   Follow the PSR-12 standard
+-   Run `vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes` before submitting
+-   Run `vendor/bin/phpstan analyse` for static analysis
+-   Add tests for new features
 
-## Dúvidas
+## Questions
 
-Abra uma issue para discutir melhorias ou problemas.
+Open an issue to discuss improvements or problems.
 

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
 Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.
 
-(Consulte o texto completo em https://www.gnu.org/licenses/gpl-3.0.txt)
+(See the full text at https://www.gnu.org/licenses/gpl-3.0.txt)
 
-Este projeto está licenciado sob a GPL-3.0-or-later.
+This project is licensed under GPL-3.0-or-later.
 

--- a/README.MD
+++ b/README.MD
@@ -4,17 +4,17 @@
 [![Packagist](https://img.shields.io/packagist/v/natanael-aguiar/secure-password-generator)](https://packagist.org/packages/natanael-aguiar/secure-password-generator)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
-This PHP package allows you to generate secure passwords with configurable options, including uppercase letters, lowercase letters, numbers and special characters.
+This PHP package allows you to generate secure passwords with configurable options, including uppercase letters, lowercase letters, numbers, and special characters.
 
-## Instalação
+## Installation
 
-Você pode instalar este pacote usando o Composer:
+You can install this package using Composer:
 
 ```bash
 composer require natanael-aguiar/secure-password-generator
 ```
 
-## Uso
+## Usage
 
 ```php
 <?php
@@ -39,41 +39,42 @@ try {
 }
 ```
 
-## Documentação
+## Documentation
 
-### `SecurePasswordGenerator` (Classe Principal)
+### `SecurePasswordGenerator` (Main Class)
 
-#### Métodos
+#### Methods
 
--   `allowLowercase(bool $allow): void` - Habilita ou desabilita letras minúsculas na senha.
--   `allowUppercase(bool $allow): void` - Habilita ou desabilita letras maiúsculas na senha.
--   `allowNumbers(bool $allow): void` - Habilita ou desabilita números na senha.
--   `allowSpecialCharacters(bool $allow): void` - Habilita ou desabilita caracteres especiais na senha.
--   `generatePassword(int $length = 12): string` - Gera uma senha segura com o comprimento especificado.
+-   `allowLowercase(bool $allow): void` - Enables or disables lowercase letters in the password.
+-   `allowUppercase(bool $allow): void` - Enables or disables uppercase letters in the password.
+-   `allowNumbers(bool $allow): void` - Enables or disables numbers in the password.
+-   `allowSpecialCharacters(bool $allow): void` - Enables or disables special characters in the password.
+-   `generatePassword(int $length = 12): string` - Generates a secure password with the specified length.
 
-## Como Contribuir
+## Contributing
 
-Veja o arquivo [CONTRIBUTING.md](CONTRIBUTING.md) para detalhes sobre o processo de contribuição.
+See the [CONTRIBUTING.md](CONTRIBUTING.md) file for details on the contribution process.
 
-## Código de Conduta
+## Code of Conduct
 
-Este projeto adota o [Código de Conduta do Contributor Covenant](CODE_OF_CONDUCT.md).
+This project adopts the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
-## Execução de Testes, Lint e Análise Estática
+## Running Tests, Lint, and Static Analysis
 
--   **Testes:**
+-   **Tests:**
     ```bash
     vendor/bin/phpunit
     ```
 -   **Lint (PSR-12):**
     ```bash
-    vendor/bin/php-cs-fixer fix --dry-run --diff
+    vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
     ```
--   **Análise Estática:**
+-   **Static Analysis:**
     ```bash
     vendor/bin/phpstan analyse
     ```
 
-## Contribuição
+## Contribution
 
-Contribuições são bem-vindas! Por favor, abra uma issue ou envie um pull request se você quiser contribuir.
+Contributions are welcome! Please open an issue or submit a pull request if you want to contribute.
+

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-require 'vendor/autoload.php'; // Carrega as classes do Composer
+require 'vendor/autoload.php'; // Loads Composer classes
 
 use SecurePasswordGenerator\SecurePasswordGenerator;
 
@@ -9,11 +9,11 @@ $generator = (new SecurePasswordGenerator())
     ->allowNumbers(true)
     ->allowSpecialCharacters(true);
 
-// Gera uma senha segura de tamanho 8
+// Generate a secure password of length 8
 try {
     $password = $generator->generatePassword(8);
     echo $password . PHP_EOL;
 } catch (Throwable $e) {
-    fwrite(STDERR, 'Erro: ' . $e->getMessage() . PHP_EOL);
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . PHP_EOL);
     exit(1);
 }

--- a/src/SecurePasswordGenerator.php
+++ b/src/SecurePasswordGenerator.php
@@ -6,9 +6,9 @@ use InvalidArgumentException;
 use Exception;
 
 /**
- * Classe para geração de senhas seguras.
+ * Class for generating secure passwords.
  *
- * Permite gerar senhas aleatórias utilizando diferentes conjuntos de caracteres.
+ * Allows generating random passwords using different character sets.
  *
  * @package SecurePasswordGenerator
  */
@@ -25,9 +25,9 @@ class SecurePasswordGenerator
     private bool $useSpecialCharacters = true;
 
     /**
-     * Permite o uso de caracteres minúsculos na senha gerada.
+     * Allows the use of lowercase characters in the generated password.
      *
-     * @param bool $allow Se true, caracteres minúsculos serão usados.
+     * @param bool $allow If true, lowercase characters will be used.
      * @return $this
      */
     public function allowLowercase(bool $allow): self
@@ -37,9 +37,9 @@ class SecurePasswordGenerator
     }
 
     /**
-     * Permite o uso de caracteres maiúsculos na senha gerada.
+     * Allows the use of uppercase characters in the generated password.
      *
-     * @param bool $allow Se true, caracteres maiúsculos serão usados.
+     * @param bool $allow If true, uppercase characters will be used.
      * @return $this
      */
     public function allowUppercase(bool $allow): self
@@ -49,9 +49,9 @@ class SecurePasswordGenerator
     }
 
     /**
-     * Permite o uso de números na senha gerada.
+     * Allows the use of numbers in the generated password.
      *
-     * @param bool $allow Se true, números serão usados.
+     * @param bool $allow If true, numbers will be used.
      * @return $this
      */
     public function allowNumbers(bool $allow): self
@@ -61,9 +61,9 @@ class SecurePasswordGenerator
     }
 
     /**
-     * Permite o uso de caracteres especiais na senha gerada.
+     * Allows the use of special characters in the generated password.
      *
-     * @param bool $allow Se true, caracteres especiais serão usados.
+     * @param bool $allow If true, special characters will be used.
      * @return $this
      */
     public function allowSpecialCharacters(bool $allow): self
@@ -73,17 +73,17 @@ class SecurePasswordGenerator
     }
 
     /**
-     * Gera uma senha aleatória baseada nos conjuntos de caracteres permitidos.
+     * Generates a random password based on the allowed character sets.
      *
-     * @param int $length Comprimento da senha (mínimo: 4, padrão: 12).
-     * @return string Senha gerada.
-     * @throws InvalidArgumentException Se o comprimento for inválido.
-     * @throws Exception Se nenhum conjunto de caracteres estiver habilitado.
+     * @param int $length Password length (minimum: 4, default: 12).
+     * @return string Generated password.
+     * @throws InvalidArgumentException If the length is invalid.
+     * @throws Exception If no character set is enabled.
      */
     public function generatePassword(int $length = 12): string
     {
         if ($length < 4) {
-            throw new InvalidArgumentException('O comprimento mínimo da senha é 4.');
+            throw new InvalidArgumentException('The minimum password length is 4.');
         }
 
         $characters = '';
@@ -106,23 +106,23 @@ class SecurePasswordGenerator
         }
 
         if (empty($characters)) {
-            throw new Exception("Nenhum conjunto de caracteres foi especificado para gerar a senha. Habilite ao menos um conjunto (minúsculas, maiúsculas, números ou especiais).");
+            throw new Exception("No character set was specified to generate the password. Please enable at least one set (lowercase, uppercase, numbers or special characters).");
         }
 
         $password = '';
         $characterSetLength = strlen($characters);
 
-        // Garante pelo menos um caractere de cada conjunto habilitado
+        // Ensure at least one character from each enabled set
         foreach ($charSets as $set) {
             $password .= $set[random_int(0, strlen($set) - 1)];
         }
 
-        // Preenche o restante da senha
+        // Fill the rest of the password
         for ($i = strlen($password); $i < $length; $i++) {
             $password .= $characters[random_int(0, $characterSetLength - 1)];
         }
 
-        // Embaralha para não deixar os primeiros caracteres previsíveis
+        // Shuffle to avoid predictable first characters
         $password = str_shuffle($password);
 
         return $password;


### PR DESCRIPTION
Translate all documentation, comments, and user-facing messages from Portuguese to English, standardizing the project for the international open-source community.